### PR TITLE
bug(ES-839969): resolved the IBM's child node not added in Navigation pane in fileManager

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,19 +526,7 @@ function recursiveFileDelete(prefix) {
  * Function to delete the file
  */
 function deleteFile(req, name, res) {
-    var isDeletePrevented = false;
     return new Promise((resolve, reject) => {
-        if(res!= null && req.headers.origin == "https://ej2.syncfusion.com"){
-            isDeletePrevented = true;
-            var errorMsg = new Error();
-            errorMsg.message =  "File Manager's delete functionality is restricted in the online demo. If you need to test delete functionality, please install Syncfusion Essential Studio on your machine and run the demo";
-            errorMsg.code = "401";
-            response = { error: errorMsg };
-            response = JSON.stringify(response);
-            res.setHeader('Content-Type', 'application/json');
-            res.json(response);
-        }
-        if(!isDeletePrevented){
         promiseList = [];
         if (name) {
             req.body.names = [name];
@@ -598,7 +586,7 @@ function deleteFile(req, name, res) {
             });
         }
         }
-    });
+    );
 }
 
 /**
@@ -1132,7 +1120,7 @@ app.post('/', function (req, res) {
                     dateModified: new Date(),
                     dateCreated: new Date(),
                     type: "",
-                    filterPath: req.body.path,
+                    filterPath: req.body.data.length > 0 ? req.body.path : "",
                 };
                 response = {
                     cwd: cwdFile,

--- a/index.js
+++ b/index.js
@@ -585,8 +585,7 @@ function deleteFile(req, name, res) {
                 });
             });
         }
-        }
-    );
+    });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -526,7 +526,19 @@ function recursiveFileDelete(prefix) {
  * Function to delete the file
  */
 function deleteFile(req, name, res) {
+    var isDeletePrevented = false;
     return new Promise((resolve, reject) => {
+        if(res!= null && req.headers.origin == "https://ej2.syncfusion.com"){
+            isDeletePrevented = true;
+            var errorMsg = new Error();
+            errorMsg.message =  "File Manager's delete functionality is restricted in the online demo. If you need to test delete functionality, please install Syncfusion Essential Studio on your machine and run the demo";
+            errorMsg.code = "401";
+            response = { error: errorMsg };
+            response = JSON.stringify(response);
+            res.setHeader('Content-Type', 'application/json');
+            res.json(response);
+        }
+        if(!isDeletePrevented){
         promiseList = [];
         if (name) {
             req.body.names = [name];
@@ -584,6 +596,7 @@ function deleteFile(req, name, res) {
                     resolve(data);
                 });
             });
+        }
         }
     });
 }


### PR DESCRIPTION
### Bug description

- Child nodes not rendered for navigation Pane in IBM provider

### Root cause

-  new condition added for console error while renaming, that condition cause this issue.
- Also other providers reeturn the empty string in filter path for root folder so that other providers has no issue. But IBM returns the path for root folder so that condition is failed then child nodes not added for navigation Pane

### Solution description

-  changed the filter path value in IBM provider like other providers

### Reason for not identifying earlier
 * [ ] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [x] If any other reason, provide the details here. 

Not ensured the SB samples
     
#### Areas tested against this fix

- Provide details about the areas or combinations that have been tested against these code changes.

* I have Ensured the IBM sample basic actions
 
### Is it a breaking issue?
* [x]  Yes, Tag `breaking-issue`. 
* [ ]  NO

 If yes, provide the breaking commit details / MR here. 
https://github.com/essential-studio/ej2-filemanager-component/commit/bddd91e4cf63b2f2e23c7022f844912dd3977d89
 ### Output Screenshot


## Reviewer Checklist
* [ ]  All provided information are reviewed and ensured.