### PR TITLE
bug(ES-826698): Script error occurs while rename any folder in IBM sample in the Blazor FileManager.

### DIFF
--- a/index.js
+++ b/index.js
@@ -932,6 +932,7 @@ app.post('/', function (req, res) {
                 var cwd = getCWDObjects();
                 var files = [];
                 cwd.name = req.body.newName;
+                cwd.filterPath = req.body.path;
                 hasChild(req.body.path.substr(1, req.body.path.length) + req.body.newName + "/").then(function (data) {
                     cwd.hasChild = data;
                     cwd.type = "";


### PR DESCRIPTION
### Bug description

- Script error occurs while rename any folder in IBM sample in the Blazor FileManager.

### Root cause

-  The script error in the FileManager component occurs because the filter path value is obtained as null when renaming the folder or file.

### Solution description

- To resolve this script error, it is necessary to send additional filter path details from the service. 

### Reason for not identifying earlier
 * [ ] Guidelines not followed. If yes, provide which guideline is not followed.

 * [ ] Guidelines not given. If yes, provide which/who need to address.
    Tag label `update-guideline-coreteam` or `update-guideline-productteam`. 

 * [x] If any other reason, provide the details here. 

Not ensured the component focusing in programatically.
     
#### Areas tested against this fix

- Provide details about the areas or combinations that have been tested against these code changes.

* Focus the element using button click.
* Ensured the basic cases.
 
### Is it a breaking issue?
* [ ]  Yes, Tag `breaking-issue`. 
* [x]  NO
 
 If yes, provide the breaking commit details / MR here. 


 ### Output Screenshot
NA

## Reviewer Checklist
* [ ]  All provided information are reviewed and ensured.