### PR TITLE
890544: Resolve the IBM console issue while opening nested folder.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1128,14 +1128,14 @@ app.post('/', function (req, res) {
                     type: "",
                     hasChild : data.CommonPrefixes.length > 0 ? true : false
                 };
+                getFilesList(req).then(data => {
+                    response = {
+                        cwd: cwdFile,
+                        files: data
+                    };
+                    responseDetails(res, response);
+                });
             });
-            getFilesList(req).then(data => {
-                response = {
-                    cwd: cwdFile,
-                    files: data
-                };
-                responseDetails(res, response);
-            })
 
         } else {
             cos.listObjects({ Bucket: awsConfig.bucketName.toString(), Delimiter: "/" }, function (err, data) {
@@ -1149,14 +1149,14 @@ app.post('/', function (req, res) {
                     filterPath: req.body.data.length > 0 ? req.body.path : "",
                     hasChild : data.CommonPrefixes.length > 0 ? true : false
                 };
+                getFilesList(req).then(data => {
+                    response = {
+                        cwd: cwdFile,
+                        files: data
+                    };
+                    responseDetails(res, response);
+                });
             });
-            getFilesList(req).then(data => {
-                response = {
-                    cwd: cwdFile,
-                    files: data
-                };
-                responseDetails(res, response);
-            })
         }
     }
 });


### PR DESCRIPTION
**Description:**
1. Script error occurs while perform double click action in second folder of IBM sample.

**Solution**
1. Modify the read operation to avoid returning null response through **getFilesList** method.