### PR TITLE
912420: Fixed navigation pane cut and paste action issue in File Manager with IBM cloud object storage file provider.

### DIFF
--- a/index.js
+++ b/index.js
@@ -741,7 +741,7 @@ function copyMoveOperations(action, req, res) {
                 files.push(cwd);
                 promiseList = [];
                 if (action == "move") {
-                    deleteFile(req, req.body.name, null).then(function (data) {
+                    deleteFile(req, req.body.name, res).then(function (data) {
                         response = {
                             files: files, error: null,
                             details: null, cwd: null


### PR DESCRIPTION
### Description:

Navigation pane cut and paste action issue in File Manager with IBM cloud object storage file provider.

### Solution:

When performing a move operation (cut and paste), the deleteFile function requires the res parameter to properly send HTTP responses. Without this parameter, the setHeader function throws an error as it has no response object to work with.